### PR TITLE
Add exitCode to resolve so it is passed in the promise chain.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = {
 
         karma.start(options.karma, function(exitCode) {
             console.log('Karma has exited with ' + exitCode);
-            deferred.resolve();
+            deferred.resolve(exitCode);
 
             // Close the static server after karma exists
             staticServer.close()


### PR DESCRIPTION
Adding exitCode to resolve allows to connect this result to other tasks connected in the promise chain.

E.g. gulp task result could be aligned with karma result, so that if karma fails the task will fail also.